### PR TITLE
Explicitly set public nameserver for DNS verification

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,8 @@ resource "acme_certificate" "certificate" {
   common_name               = var.domain
   subject_alternative_names = var.wildcard_domain ? ["*.${var.domain}"] : []
 
+  recursive_nameservers = ["8.8.8.8:53"]
+
   dns_challenge {
     provider = "route53"
 


### PR DESCRIPTION
On `podman` for MacOS it appears that the container runtime/podman machine DNS nameserver can have problems finding SOA records for domains. This does not occur natively or with docker container runtimes (tested on Linux).

The addition of an explicit public nameserver will cause the system running the module to consult that server to verify updates before submitting the certificate signing request to ACME.